### PR TITLE
retry commands invalid read fix

### DIFF
--- a/lib/cside/src/calls.c
+++ b/lib/cside/src/calls.c
@@ -32,7 +32,7 @@ arg_t remote_sync_call(tboard_t* t, char* cmd_func, char* fn_sig, ...) {
     retarg.type = rarg->type;
     retarg.val = rarg->val;
 
-    command_args_free(qargs);
+    //command_args_free(qargs);
     free(rarg);
     return retarg;
 }
@@ -53,7 +53,7 @@ bool remote_async_call(tboard_t* t, char* cmd_func, char* fn_sig, ...) {
         va_end(args);
     }
     bool rval = remote_task_create_nb(t, cmd_func, level, fn_sig, qargs, strlen(fn_sig));
-    command_args_free(qargs);
+    //command_args_free(qargs);
     return rval;
 }
 

--- a/lib/cside/src/calls.c
+++ b/lib/cside/src/calls.c
@@ -32,7 +32,6 @@ arg_t remote_sync_call(tboard_t* t, char* cmd_func, char* fn_sig, ...) {
     retarg.type = rarg->type;
     retarg.val = rarg->val;
 
-    //command_args_free(qargs);
     free(rarg);
     return retarg;
 }
@@ -53,7 +52,6 @@ bool remote_async_call(tboard_t* t, char* cmd_func, char* fn_sig, ...) {
         va_end(args);
     }
     bool rval = remote_task_create_nb(t, cmd_func, level, fn_sig, qargs, strlen(fn_sig));
-    //command_args_free(qargs);
     return rval;
 }
 

--- a/lib/cside/src/task.c
+++ b/lib/cside/src/task.c
@@ -312,6 +312,9 @@ arg_t* remote_task_create(tboard_t* tboard, char* command, int level, char* fn_a
             tboard_err("remote_task_create: Failed to pop remote task from mco storage interface.\n");
             return NULL;
         } else if (rtask.status == RTASK_COMPLETED) {
+            if (sizeof_args)
+                command_args_free(args); // the rtask.data value will be overwritten with return args
+
             remote_task_free(tboard, rtask.task_id);
             return rtask.data;
         }
@@ -430,8 +433,8 @@ void remote_task_destroy(remote_task_t *rtask) {
         task_destroy(rtask->calling_task);
     }
     // free alloc'd data if applicable
-    // if (rtask->data_size > 0 && rtask->data != NULL)
-    // command_args_free(rtask->data);
+    if (rtask->data_size > 0 && rtask->data != NULL)
+        command_args_free(rtask->data);
     // free rtask object
     free(rtask);
 }

--- a/tests/NewCompiler/C2J_NoReturnResults/jt.c
+++ b/tests/NewCompiler/C2J_NoReturnResults/jt.c
@@ -6,10 +6,11 @@ jasync localme(int c, char* s) {
 }
 
 jasync localyou(int c, char* s) {
+    jarray int num[5] = {1, 2, 3, 4, 5};
     while(1) {
         jsys.sleep(1000000);
         printf("############-->>> Hello YOU  %d, %s\n", c, s);
-        you(s);
+        you(s, &num);
     }
 }
 

--- a/tests/NewCompiler/C2J_NoReturnResults/jt.js
+++ b/tests/NewCompiler/C2J_NoReturnResults/jt.js
@@ -1,8 +1,8 @@
 let count = 0;
 
-jasync you(str: char*) {
+jasync you(str: char*, num: int[]) {
     count++;
-    console.log("Message received: ", str, " local count ", count);
+    console.log("Message received: ", str, num, " local count ", count);
 }
 
 setInterval(()=> {


### PR DESCRIPTION
I forced the retry condition by commenting out the putAcks in the jside runtime: this is now working as expected...

We need to do the command_args_free outside of the remote_task_free because dflow tasks are using the same remote task data pipeline, so we don't want to always nuke that field